### PR TITLE
Fix Expecting property name enclosed in double quotes (#5)

### DIFF
--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -931,7 +931,7 @@ tolerations =
 # Note that if no _request_timeout is specified, the kubernetes client will wait indefinitely
 # for kubernetes api responses, which will cause the scheduler to hang.
 # The timeout is specified as [connect timeout, read timeout]
-kube_client_request_args = {{"_request_timeout" : [60,60] }}
+kube_client_request_args = {"_request_timeout" : [60,60]}
 
 # Specifies the uid to run the first process of the worker pods containers as
 run_as_user =


### PR DESCRIPTION
When using the Kubernetes executor, the airflowui and scheduler
fail to start:

```
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 37, in <module>
    args.func(args)
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/cli.py", line 75, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/airflow/bin/cli.py", line 1013, in scheduler
    do_pickle=args.do_pickle)
  File "<string>", line 4, in __init__
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/state.py", line 433, in _initialize_instance
    manager.dispatch.init_failure(self, args, kwargs)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py", line 69, in __exit__
    exc_value, with_traceback=exc_tb,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 178, in raise_
    raise exception
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/state.py", line 430, in _initialize_instance
    return manager.original_init(*mixed[1:], **kwargs)
  File "/usr/local/lib/python3.7/site-packages/airflow/jobs/scheduler_job.py", line 380, in __init__
    super(SchedulerJob, self).__init__(*args, **kwargs)
  File "<string>", line 6, in __init__
  File "/usr/local/lib/python3.7/site-packages/airflow/jobs/base_job.py", line 86, in __init__
    self.executor = executor or executors.get_default_executor()
  File "/usr/local/lib/python3.7/site-packages/airflow/executors/__init__.py", line 48, in get_default_executor
    DEFAULT_EXECUTOR = _get_executor(executor_name)
  File "/usr/local/lib/python3.7/site-packages/airflow/executors/__init__.py", line 87, in _get_executor
    return KubernetesExecutor()
  File "/usr/local/lib/python3.7/site-packages/airflow/contrib/executors/kubernetes_executor.py", line 715, in __init__
    self.kube_config = KubeConfig()
  File "/usr/local/lib/python3.7/site-packages/airflow/contrib/executors/kubernetes_executor.py", line 284, in __init__
    self.kube_client_request_args = json.loads(kube_client_request_args)
  File "/usr/local/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.7/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```