### PR TITLE
Use Quay for base image instead of DockerHub to prevent issues with rate limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # BUILD: docker build --rm -t puckel/docker-airflow .
 # SOURCE: https://github.com/puckel/docker-airflow
 
-FROM python:3.7-slim-buster
+FROM quay.io/opendatahub/python:3.7-slim-buster
 LABEL maintainer="Puckel_"
 
 # Never prompt the user for choices on installation/configuration of packages


### PR DESCRIPTION


## Related Issues and Dependencies

The CI build is hitting issues with DockerHub rate limits

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Switching to an image pulled from DH and pushed to Quay

## Description

<!--- Describe your changes in detail -->
