### PR TITLE
OAuth Multiuserfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN set -ex \
         libssl-dev \
         libffi-dev \
         libpq-dev \
+        libldap2-dev \
         git \
     ' \
     && apt-get update -yqq \
@@ -58,6 +59,7 @@ RUN set -ex \
     && useradd -ms /bin/bash -d ${AIRFLOW_USER_HOME} airflow \
     && pip install --no-cache-dir -U pip setuptools wheel \
     && pip install --no-cache-dir \
+        python-ldap \
         pytz \
         pyOpenSSL \
         ndg-httpsclient \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN set -ex \
         pyOpenSSL \
         ndg-httpsclient \
         pyasn1 \
-        apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
+        apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,s3,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
         oauthlib==2.1.0 \
         requests-oauthlib==1.1.0 \
         Flask-OAuthlib==0.9.5 \

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -412,7 +412,7 @@ navbar_color = #007A87
 default_dag_run_display_number = 25
 
 # Enable werkzeug ``ProxyFix`` middleware for reverse proxy
-enable_proxy_fix = False
+enable_proxy_fix = True
 
 # Number of values to trust for ``X-Forwarded-For``.
 # More info: https://werkzeug.palletsprojects.com/en/0.16.x/middleware/proxy_fix/


### PR DESCRIPTION
PR to fix multiple user sign up using OAuth when using the LDAP backend.

One of the issues with multi-user support is that the `email` field is not returned by the OCP users endpoint so it was previously unset by default, this makes it so more than 1 user cannot enroll. My solution for the LDAP backend is to parse the `identity` field and use the user's LDAP dn which is base64 decoded to reconstruct the user's email (or at least what LOOKS like it could be their email, it's not guaranteed to be accurate and is subject to LDAP implementation). 